### PR TITLE
Add support for parsing index blocks

### DIFF
--- a/mft/mft.go
+++ b/mft/mft.go
@@ -162,7 +162,6 @@ func ApplyFixup(b []byte) ([]byte, error) {
 	updateSequenceOffset := int(r.Uint16(0x04))
 	updateSequenceSize := int(r.Uint16(0x06))
 	return applyFixUp(b, updateSequenceOffset, updateSequenceSize)
-
 }
 
 // FindAttributes returns all attributes of the specified type contained in this record. When no matches are found an

--- a/mft/mft.go
+++ b/mft/mft.go
@@ -155,6 +155,14 @@ func applyFixUp(b []byte, offset int, length int) ([]byte, error) {
 	return b, nil
 }
 
+func ApplyFixup(b []byte) ([]byte, error) {
+	r := binutil.NewLittleEndianReader(b)
+	updateSequenceOffset := int(r.Uint16(0x04))
+	updateSequenceSize := int(r.Uint16(0x06))
+	return applyFixUp(b, updateSequenceOffset, updateSequenceSize)
+
+}
+
 // FindAttributes returns all attributes of the specified type contained in this record. When no matches are found an
 // empty slice is returned.
 func (r *Record) FindAttributes(attrType AttributeType) []Attribute {

--- a/mft/mft.go
+++ b/mft/mft.go
@@ -155,6 +155,8 @@ func applyFixUp(b []byte, offset int, length int) ([]byte, error) {
 	return b, nil
 }
 
+// ApplyFixup applies the NTFS fixup to the data of a Data Run.
+// http://inform.pucp.edu.pe/~inf232/Ntfs/ntfs_doc_v0.5/concepts/fixup.html
 func ApplyFixup(b []byte) ([]byte, error) {
 	r := binutil.NewLittleEndianReader(b)
 	updateSequenceOffset := int(r.Uint16(0x04))


### PR DESCRIPTION
Thanks for this great library! This PR adds a function to parse [IndexAllocation](http://inform.pucp.edu.pe/~inf232/Ntfs/ntfs_doc_v0.5/attributes/index_allocation.html) entries to, e.g., navigate through the directory strucuture.